### PR TITLE
Set default if no configuration is set for variables which require that

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,9 +1,9 @@
 {{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="content"><h1>{{ .Title }}</h1><p>{{ .Content }}</p>{{ range .Data.Pages }}<li>
 {{ if .Params.showDate }}
 
-{{ .Date.Format .Site.Params.dateform }} --
+{{ .Date.Format (.Site.Params.dateform | default "Mon Jan 02, 2006") }} --
 
-{{ end }}<a href="{{.Permalink}}">{{.Title}}</a></li>{{ end }}</div><div class="section bottom-menu"><hr/><p>{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
+{{ end }}<a href="{{.Permalink}}">{{.Title}}</a></li>{{ end }}</div><div class="section bottom-menu"><hr/>{{ if isset .Site.Params "mainMenu" }}<p>{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
 {{ range after 1 .Site.Params.mainMenu }}
 &#183; <a href="{{ .link }}">{{ .text }}</a>{{ end }}
-&#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p></div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>
+&#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p>{{ end }}</div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,4 @@
-{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="title">{{ .Title }}</div><div class="section" id="content">{{ .Content }}</div><div class="section bottom-menu"><hr/><p>{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
+{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="title">{{ .Title }}</div><div class="section" id="content">{{ .Content }}</div><div class="section bottom-menu"><hr/>{{ if isset .Site.Params "mainMenu" }}<p>{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
 {{ range after 1 .Site.Params.mainMenu }}
 &#183; <a href="{{ .link }}">{{ .text }}</a>{{ end }}
-&#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p></div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>
+&#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p>{{ end }}</div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>

--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -1,6 +1,6 @@
 {{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="content">{{ .Content }}</div>
 {{ if .Site.Params.clickablePhotos }}<div class="grid">
-{{ $name := .Site.Params.galleryFolder }}
+{{ $name := default "images/" .Site.Params.galleryFolder }}
 {{ $path := "gallery/" }}
 {{ $content := "/content/" }}
 {{ $src := (print $path $name) }}
@@ -13,7 +13,7 @@
 <div><a href="{{ $src | absURL }}{{.Name }}"><img src="{{ $src | absURL }}{{.Name }}"/></a></div>
 {{ end }}</div>
 {{ else }}<div class="grid">
-{{ $name := .Site.Params.galleryFolder }}
+{{ $name := default "images/" .Site.Params.galleryFolder }}
 {{ $path := "gallery/" }}
 {{ $content := "/content/" }}
 {{ $src := (print $path $name) }}
@@ -23,7 +23,7 @@
 {{ $files := readDir $folder }}
 
 {{ range shuffle $files }}
-<div><img src="{{ $src | absURL }}{{.Name }}"/></div>{{ end }}</div>{{ end }}<div class="section bottom-menu"><hr/><p>{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
+<div><img src="{{ $src | absURL }}{{.Name }}"/></div>{{ end }}</div>{{ end }}<div class="section bottom-menu"><hr/>{{ if isset .Site.Params "mainMenu" }}<p>{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
 {{ range after 1 .Site.Params.mainMenu }}
 &#183; <a href="{{ .link }}">{{ .text }}</a>{{ end }}
-&#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p></div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>
+&#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p>{{ end }}</div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,1 +1,1 @@
-{{ partial "head.html" . }}<body><div class="section" id="splash">{{ range .Site.Params.mainMenu }}<div id="big-link"> <a href="{{.link}}">{{.text}}</a></div>{{ end }}</div></body>
+{{ partial "head.html" . }}<body>{{ if isset .Site.Params "mainMenu" }}<div class="section" id="splash">{{ range .Site.Params.mainMenu }}<div id="big-link"> <a href="{{.link}}">{{.text}}</a></div>{{ end }}</div>{{ end }}</body>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,15 +14,15 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:domain" content="{{.Site.BaseURL}}">
     <!-- Min 120x120px-->
-    <meta name="twitter:image" content="{{.Site.Params.primaryImage | absURL}}">
+    <meta name="twitter:image" content="{{.Site.Params.primaryImage | default "" | absURL}}">
     <meta name="twitter:title" property="og:title" itemprop="title name" content="{{.Site.Params.title}}">
     <meta name="twitter:description" property="og:description" itemprop="description" content="{{.Site.Params.description}}">
     <meta name="og:type" content="website">
     <meta name="og:url" content="{{.Site.BaseURL}}">
-    <meta name="og:image" itemprop="image primaryImageOfPage" content="{{.Site.Params.primaryImage | absURL}}">
+    <meta name="og:image" itemprop="image primaryImageOfPage" content="{{.Site.Params.primaryImage | default "" | absURL}}">
     <!-- Characters max 60-->
     <title>{{.Site.Title}}</title>
-    <link rel="shortcut icon" href="{{.Site.Params.favicon | absURL }}" id="favicon">
+    <link rel="shortcut icon" href="{{.Site.Params.favicon  | default "favicon.ico" | absURL }}" id="favicon">
     <link rel="stylesheet" href="{{ "css/style.css" | absURL}}">
     <!-- Google fonts-->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Didact+Gothic">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,7 +1,7 @@
-{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="title">{{ .Title }}</div><div class="section" id="content">{{ .Date.Format .Site.Params.dateform }} &#183; {{ .WordCount }} words
+{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="title">{{ .Title }}</div><div class="section" id="content">{{ .Date.Format (.Site.Params.dateform | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
 
 {{ with .Params.tags }}<div>{{ range . }}<span id="tag"><a href="{{ "tags/" | absURL }}{{ . | urlize }}">{{.}}</a></span>{{ end }}</div>{{ end }}<hr/>{{ .Content }}</div><div class="section bottom-menu"><hr/><p><a href="{{ .Section | relURL }}">back</a> &#183;
-{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
+{{ if isset .Site.Params "mainMenu" }}{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
 {{ range after 1 .Site.Params.mainMenu }}
-&#183; <a href="{{ .link }}">{{ .text }}</a>{{ end }}
+&#183; <a href="{{ .link }}">{{ .text }}</a>{{ end }}{{ end }}
 &#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p></div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>

--- a/pug/_default/list.pug
+++ b/pug/_default/list.pug
@@ -10,7 +10,7 @@ body
                 |
                 | {{ if .Params.showDate }}
                 |
-                | {{ .Date.Format .Site.Params.dateform }} --
+                | {{ .Date.Format (.Site.Params.dateform | default "Mon Jan 02, 2006") }} --
                 |
                 | {{ end }}
                 a(href='{{.Permalink}}') {{.Title}}
@@ -18,14 +18,16 @@ body
         .section.bottom-menu
             hr
             p
+            {{ if isset .Site.Params "mainMenu" }}
                 | {{ range first 1 .Site.Params.mainMenu }}
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
                 | {{ range after 1 .Site.Params.mainMenu }}
-                | &#183; 
+                | &#183;
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
-                | &#183; 
+            {{ end }}
+                | &#183;
                 a(href='{{.Site.BaseURL}}') {{ .Site.Params.homepage }}
         .section.footer
             | {{ partial "footer.html" . }}

--- a/pug/_default/single.pug
+++ b/pug/_default/single.pug
@@ -9,14 +9,16 @@ body
         .section.bottom-menu
             hr
             p
+            {{ if isset .Site.Params "mainMenu" }}
                 | {{ range first 1 .Site.Params.mainMenu }}
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
                 | {{ range after 1 .Site.Params.mainMenu }}
-                | &#183; 
+                | &#183;
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
-                | &#183; 
+            {{ end }}
+                | &#183;
                 a(href='{{.Site.BaseURL}}') {{ .Site.Params.homepage }}
         .section.footer
             | {{ partial "footer.html" . }}

--- a/pug/gallery/list.pug
+++ b/pug/gallery/list.pug
@@ -46,14 +46,16 @@ body
         .section.bottom-menu
             hr
             p
+            {{ if isset .Site.Params "mainMenu" }}
                 | {{ range first 1 .Site.Params.mainMenu }}
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
                 | {{ range after 1 .Site.Params.mainMenu }}
-                | &#183; 
+                | &#183;
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
-                | &#183; 
+            {{ end }}
+                | &#183;
                 a(href='{{.Site.BaseURL}}') {{ .Site.Params.homepage }}
         .section.footer
             | {{ partial "footer.html" . }}

--- a/pug/index.pug
+++ b/pug/index.pug
@@ -1,8 +1,10 @@
 | {{ partial "head.html" . }}
 
+{{ if isset .Site.Params "mainMenu" }}
 body
     .section#splash
         | {{ range .Site.Params.mainMenu }}
-        #big-link 
+        #big-link
             a(href='{{.link}}') {{.text}}
         | {{ end }}
+{{ end }}

--- a/pug/posts/single.pug
+++ b/pug/posts/single.pug
@@ -5,7 +5,7 @@ body
         .section#title
             | {{ .Title }}
         .section#content
-            | {{ .Date.Format .Site.Params.dateform }} &#183; {{ .WordCount }} words
+            | {{ .Date.Format (.Site.Params.dateform | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
             |
             | {{ with .Params.tags }}
             div
@@ -21,14 +21,16 @@ body
             p
                 a(href='{{ .Section | relURL }}') back
                 |  &#183;
+            {{ if isset .Site.Params "mainMenu" }}
                 | {{ range first 1 .Site.Params.mainMenu }}
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
                 | {{ range after 1 .Site.Params.mainMenu }}
-                | &#183; 
+                | &#183;
                 a(href='{{ .link }}') {{ .text }}
                 | {{ end }}
-                | &#183; 
+            {{ end }}
+                | &#183;
                 a(href='{{.Site.BaseURL}}') {{ .Site.Params.homepage }}
         .section.footer
             | {{ partial "footer.html" . }}


### PR DESCRIPTION
Fix #1 - site will be generated even with empty config.toml, `/posts`, `/tags` and `/gallery` will be present.