### PR TITLE
Fix: OpenGraph/Twitter Card does not properly retrieve title from con…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
     <meta name="twitter:domain" content="{{.Site.BaseURL}}">
     <!-- Min 120x120px-->
     <meta name="twitter:image" content="{{ .Site.Params.primaryImage | default "tn.png" | absURL }}">
-    <meta name="twitter:title" property="og:title" itemprop="title name" content="{{.Site.Params.title | default "Sam"}}">
+    <meta name="twitter:title" property="og:title" itemprop="title name" content="{{.Site.Title | default "Sam"}}">
     <meta name="twitter:description" property="og:description" itemprop="description" content="{{.Site.Params.description | default "Call me Sam, a theme for Hugo."}}">
     <meta name="og:type" content="website">
     <meta name="og:url" content="{{.Site.BaseURL}}">


### PR DESCRIPTION
…fig.toml

Previously, the meta tag for the OpenGraph title field attempted to retrieve the site's title from a parameter that did not exist, causing it to always return "Sam". This fix changes the code to pull the title from the correct parameter.