### PR TITLE
fix: allow only one mainMenu item

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,6 +4,8 @@
 {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006")}} --
 
 {{ end }}<a href="{{.Permalink}}">{{.Title}}</a></li>{{ end }}</div>{{ if .Site.Params.mainMenu }}<div class="section bottom-menu"><hr/><p>{{ range first 1 .Site.Params.mainMenu }}<a href="{{ .link }}">{{ .text }}</a>{{ end }}
+{{ if ( gt ( len .Site.Params.mainMenu ) 1 ) }}
 {{ range after 1 .Site.Params.mainMenu }}
 &#183; <a href="{{ .link }}">{{ .text }}</a>{{ end }}
+{{ end }}
 &#183; <a href="{{.Site.BaseURL}}">{{ .Site.Params.homepage }}</a></p></div>{{ end }}<div class="section footer">{{ partial "footer.html" . }}</div></div></body>


### PR DESCRIPTION
Currently the theme errors if there is only one item in `.Site.Params.mainMenu`, as follows:

```
Building sites … ERROR 2018/05/01 18:27:08 Error while rendering "taxonomyTerm" in "": template: theme/_default/list.html:7:9: executing "theme/_default/list.html" at <after 1 .Site.Params...>: error calling after: no items left
```

This change wraps that `range` in a conditional to ensure that it won't
run if it would return zero lines.